### PR TITLE
Fix peer dependency for fastify

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "peerDependencies": {
-    "fastify": "^4 || ^5",
+    "fastify": "^3",
     "marko": "^4 || ^5"
   },
   "repository": {


### PR DESCRIPTION
This is happening in a newer version of npm and this only shows a warning in previous ones
Latest fastify is a ^3. version

This is the error we get right now when doing an `npm install` or installing throufh marko cli

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: my-app@1.0.0
npm ERR! Found: fastify@undefined
npm ERR! node_modules/fastify
npm ERR!   fastify@"^4.14.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer fastify@"^4 || ^5" from @marko/fastify@1.0.1
npm ERR! node_modules/@marko/fastify
npm ERR!   @marko/fastify@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/ma/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ma/.npm/_logs/2021-03-11T16_22_08_589Z-debug.log
```