### PR TITLE
Fix for issue#6

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,8 +56,11 @@ export default plugin<never>(((fastify, _options, done) => {
           input.$global = $global;
         }
 
-        this.type("text/html; charset=utf-8");
-        template.stream(input || { $global }).pipe(this.raw);
+        // Disable fastify-compression for this stream
+        this.request.headers["x-no-compression"] = "true";
+        return this.type("text/html; charset=utf-8").send(
+          template.stream(input || { $global })
+        );
       }
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,8 @@ export default plugin<never>(((fastify, _options, done) => {
           input.$global = $global;
         }
 
-        return this.type("text/html; charset=utf-8").send(
-          template.stream(input || { $global })
-        );
+        this.type("text/html; charset=utf-8");
+        template.stream(input || { $global }).pipe(this.raw);
       }
     );
 


### PR DESCRIPTION
Fix for [issue#6](https://github.com/marko-js/fastify/issues/6)

## Motivation and Context
This bypasses the normal .send(stream) format of fastify. Instead the template stream gets sent to the raw reply stream directly, fixing the issue described above.

## Checklist:
- [ ] I have updated/added documentation affected by my changes.
- [ ] none of the above apply 🤷‍♂️
- [ ] I have added tests to cover my changes.

